### PR TITLE
feat: auth/refresh api 연결

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -22,11 +22,15 @@ export default function App() {
           "isLoggedIn",
           "accessToken",
         ]);
-
         if (loginStatus[1] === "true" && token[1]) {
           setIsLoggedIn(true);
         } else {
-          await AsyncStorage.multiRemove(["isLoggedIn", "accessToken"]);
+          await AsyncStorage.multiRemove([
+            "isLoggedIn",
+            "accessToken",
+            "refreshToken",
+            "jti",
+          ]);
           setIsLoggedIn(false);
         }
       } catch (error) {

--- a/src/api/axios-interceptor.ts
+++ b/src/api/axios-interceptor.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { navigate } from "../navigation/NavigationService";
+import { navigate, navigationRef } from "../navigation/NavigationService";
+import { Alert } from "react-native";
+import { CommonActions } from "@react-navigation/native";
 
 const axiosInstance = axios.create({
   baseURL: "http://13.125.58.70:8080",
@@ -10,10 +12,13 @@ const axiosInstance = axios.create({
   },
 });
 
-// Request Interceptor
+const refreshAxios = axios.create({
+  baseURL: "http://13.125.58.70:8080",
+  timeout: 5000,
+});
+
 axiosInstance.interceptors.request.use(
   async (config) => {
-    // 로그인, 회원가입, 토큰 리프레시 요청은 제외
     if (
       config.url === "/auth/login" ||
       config.url === "/auth/signup" ||
@@ -34,44 +39,72 @@ axiosInstance.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-// Response Interceptor
 axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
 
-    // 401 에러이고 재시도하지 않은 요청일 경우
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (
+      error.response?.status === 500 &&
+      error.response?.data?.message?.includes("JWT expired") &&
+      !originalRequest._retry
+    ) {
       originalRequest._retry = true;
 
       try {
-        // refreshToken을 body에 담아 새 토큰 요청
         const refreshToken = await AsyncStorage.getItem("refreshToken");
-        const response = await axios.post(
-          "http://13.125.58.70:8080/auth/refresh",
-          { refreshToken } // refreshToken을 body에 담아 전송
-        );
+        console.log("Attempting refresh with token:", refreshToken);
 
-        // 새 토큰 저장
-        const { accessToken, refreshToken: newRefreshToken } = response.data;
+        const response = await refreshAxios.post("/auth/refresh", null, {
+          headers: { refreshToken },
+        });
+
+        console.log("Refresh response:", response.data);
+
+        const {
+          accessToken,
+          refreshToken: newRefreshToken,
+          jti,
+        } = response.data;
         await AsyncStorage.multiSet([
           ["accessToken", accessToken],
           ["refreshToken", newRefreshToken],
+          ["jti", jti],
         ]);
 
-        // 새 토큰으로 원래 요청 재시도
         originalRequest.headers.Authorization = `Bearer ${accessToken}`;
         return axiosInstance(originalRequest);
-      } catch (refreshError) {
-        // refresh token도 만료된 경우
+      } catch (error) {
+        if (axios.isAxiosError(error)) {
+          console.log("Refresh Error details:", {
+            status: error.response?.status,
+            data: error.response?.data,
+            message: error.message,
+          });
+        } else {
+          console.log("Non-Axios Error:", error);
+        }
+
+        console.log("토큰 갱신 실패, 로그아웃 처리...");
         await AsyncStorage.multiRemove([
           "jti",
           "accessToken",
           "refreshToken",
           "isLoggedIn",
         ]);
-        navigate("Login");
-        return Promise.reject(refreshError);
+
+        navigationRef.current?.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "Login" }],
+          })
+        );
+
+        Alert.alert(
+          "세션 만료",
+          "로그인이 만료되었습니다. 다시 로그인해주세요."
+        );
+        return Promise.reject(error);
       }
     }
 

--- a/src/screens/main/MyPageScreen.tsx
+++ b/src/screens/main/MyPageScreen.tsx
@@ -22,8 +22,13 @@ import WithdrawalModal from "../../components/mypage/WithdrawalModal";
 import OptionsModal from "../../components/mypage/OptionsModal";
 import { withdrawMembership } from "../../api/member";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { MyPageNavigationProp } from "../../types/navigation";
 
-export const MyPageScreen = ({ navigation }: { navigation: any }) => {
+export const MyPageScreen = ({
+  navigation,
+}: {
+  navigation: MyPageNavigationProp;
+}) => {
   const handleLogout = useLogout();
   const {
     userProfile,
@@ -58,6 +63,26 @@ export const MyPageScreen = ({ navigation }: { navigation: any }) => {
     }
   };
 
+  useEffect(() => {
+    const checkAuthAndFetchProfile = async () => {
+      try {
+        const token = await AsyncStorage.getItem("accessToken");
+        if (!token) {
+          navigation.reset({
+            index: 0,
+            routes: [{ name: "Start" }],
+          });
+          return;
+        }
+
+        await fetchProfile();
+      } catch (error) {
+        console.error("프로필 조회 실패:", error);
+      }
+    };
+
+    checkAuthAndFetchProfile();
+  }, [fetchProfile, navigation]);
   useEffect(() => {
     const listener = () => {
       loadParticipations();

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,6 +1,7 @@
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Participation } from "./participation";
+import { CompositeNavigationProp } from "@react-navigation/native";
 
 export type RootStackParamList = {
   Start: undefined;
@@ -43,7 +44,10 @@ export type MyPageStackParamList = {
   };
 };
 
-type MyPageNavigationProp = StackNavigationProp<MyPageStackParamList>;
+export type MyPageNavigationProp = CompositeNavigationProp<
+  StackNavigationProp<RootStackParamList, "Start">,
+  StackNavigationProp<MyPageStackParamList>
+>;
 
 export type ParticipationListProps = {
   participations: Participation[];

--- a/src/utils/hooks/useUserProfile.ts
+++ b/src/utils/hooks/useUserProfile.ts
@@ -1,23 +1,33 @@
-// hooks/useUserProfile.ts
 import { useState, useCallback } from "react";
+import { Alert } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import axios from "axios";
 import axiosInstance from "../../api/axios-interceptor";
 import { UserProfile } from "../../types/mypage";
+import { TNavigationProp } from "../../types/navigation";
 
 export const useUserProfile = () => {
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const navigation = useNavigation<TNavigationProp>();
 
   const fetchProfile = useCallback(async () => {
     try {
       const response = await axiosInstance.get("/member/mypage");
       setUserProfile(response.data);
     } catch (error) {
-      console.error("프로필 조회 실패:", error);
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        Alert.alert("세션이 만료되었습니다", "다시 로그인해주세요");
+        navigation.reset({
+          index: 0,
+          routes: [{ name: "Start" }],
+        });
+      }
       setUserProfile(null);
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [navigation]);
 
   return {
     userProfile,


### PR DESCRIPTION
- accessToken 없을 시 모든 인증 데이터 삭제
- refreshToken header에 담아 전송
- refreshToken 만료시 login 화면으로 리셋(뒤로가기 불가능)